### PR TITLE
Updated regex to allow dash

### DIFF
--- a/proxmox.php
+++ b/proxmox.php
@@ -16,7 +16,7 @@ class Proxmox extends Module
     /**
      * @var string The version of this module
      */
-    private static $version = '2.4.0';
+    private static $version = '2.4.1';
     /**
      * @var string The authors of this module
      */

--- a/proxmox.php
+++ b/proxmox.php
@@ -2424,7 +2424,7 @@ class Proxmox extends Module
             ],
             'storage' => [
                 'format' => [
-                    'rule' => ['matches', '/^[0-9a-zA-Z]+$/'],
+                    'rule' => ['matches', '/^[0-9a-zA-Z\-]+$/'],
                     'message' => Language::_('Proxmox.!error.storage.format', true)
                 ]
             ],


### PR DESCRIPTION
Allow dash in the "Default storage name" field as Proxmox defaults uses local-lvm.